### PR TITLE
Update rhai, mlua and rquickjs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,27 +1361,27 @@ dependencies = [
 
 [[package]]
 name = "rquickjs"
-version = "0.6.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cbd33e0b668aea0ab238b9164523aca929096f9f40834700d71d91dd4888882"
+checksum = "d16661bff09e9ed8e01094a188b463de45ec0693ade55b92ed54027d7ba7c40c"
 dependencies = [
  "rquickjs-core",
 ]
 
 [[package]]
 name = "rquickjs-core"
-version = "0.6.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9129d69b7b8f7ee8ad1da5b12c7f4a8a8acd45f2e6dd9cb2ee1bc5a1f2fa3d"
+checksum = "6c8db6379e204ef84c0811e90e7cc3e3e4d7688701db68a00d14a6db6849087b"
 dependencies = [
  "rquickjs-sys",
 ]
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.6.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6f2288d8e7fbb5130f62cf720451641e99d55f6fde9db86aa2914ecb553fd2"
+checksum = "4bc352c6b663604c3c186c000cfcc6c271f4b50bc135a285dd6d4f2a42f9790a"
 dependencies = [
  "cc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61797318be89b1a268a018a92a7657096d83f3ecb31418b9e9c16dcbb043b702"
+checksum = "8867cfc57aaf2320b60ec0f4d55603ac950ce852e6ab6b9109aa3d626a4dd7ea"
 dependencies = [
  "ahash",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "luau0-src"
-version = "0.11.0+luau647"
+version = "0.11.1+luau650"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca47356c40f9121e3b3d582bf7355e8b25751b2e8afdfda49cf05775dfbc6b0a"
+checksum = "6940dda003977234fe07c0480a8a05eecea5bed3030567c383336ea432c74d0a"
 dependencies = [
  "cc",
 ]
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6ddbd668297c46be4bdea6c599dcc1f001a129586272d53170b7ac0a62961e"
+checksum = "0ae9546e4a268c309804e8bbb7526e31cbfdedca7cd60ac1b987d0b212e0d876"
 dependencies = [
  "bstr",
  "either",
@@ -865,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eebac25c35a13285456c88ee2fde93d9aee8bcfdaf03f9d6d12be3391351ec"
+checksum = "efa6bf1a64f06848749b7e7727417f4ec2121599e2a10ef0a8a3888b0e9a5a0d"
 dependencies = [
  "cc",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ boa_gc = { version = "0.19.1", optional = true }
 boa_runtime = { version = "0.19.1", optional = true }
 mlua = { version = "0.10.1", optional = true }
 rhai = { version = "1.20.0", optional = true }
-rquickjs = { version = "0.6.2", optional = true }
+rquickjs = { version = "0.8.1", optional = true }
 rune = { version = "0.13.4", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ boa_engine = { version = "0.19.1", optional = true }
 boa_gc = { version = "0.19.1", optional = true }
 boa_runtime = { version = "0.19.1", optional = true }
 mlua = { version = "0.10.0", optional = true }
-rhai = { version = "1.19.0", optional = true }
+rhai = { version = "1.20.0", optional = true }
 rquickjs = { version = "0.6.2", optional = true }
 rune = { version = "0.13.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ itertools = { version = "0.13", optional = true }
 boa_engine = { version = "0.19.1", optional = true }
 boa_gc = { version = "0.19.1", optional = true }
 boa_runtime = { version = "0.19.1", optional = true }
-mlua = { version = "0.10.0", optional = true }
+mlua = { version = "0.10.1", optional = true }
 rhai = { version = "1.20.0", optional = true }
 rquickjs = { version = "0.6.2", optional = true }
 rune = { version = "0.13.4", optional = true }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Simply run the `bench.py` script to generate images. It requires `cargo criterio
 |----------|-------------------------------|
 | OS       | Ubuntu 22.04, m6i.16xlarge    |
 | boa      | v0.19.1                       |
-| mlua     | v0.10.0                       |
+| mlua     | v0.10.1                       |
 | rhai     | v1.20.0                       |
 | rquickjs | v0.6.2                        |
 | rune     | v0.13.4                       |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simply run the `bench.py` script to generate images. It requires `cargo criterio
 | OS       | Ubuntu 22.04, m6i.16xlarge    |
 | boa      | v0.19.1                       |
 | mlua     | v0.10.0                       |
-| rhai     | v1.19.0                       |
+| rhai     | v1.20.0                       |
 | rquickjs | v0.6.2                        |
 | rune     | v0.13.4                       |
 | rustc    | v1.81.0                       |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Simply run the `bench.py` script to generate images. It requires `cargo criterio
 | boa      | v0.19.1                       |
 | mlua     | v0.10.1                       |
 | rhai     | v1.20.0                       |
-| rquickjs | v0.6.2                        |
+| rquickjs | v0.8.1                        |
 | rune     | v0.13.4                       |
 | rustc    | v1.81.0                       |
 

--- a/src/rquickjs.rs
+++ b/src/rquickjs.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 
 use rand::Rng;
-use rquickjs::class::{Class, ClassId, JsClass, Readable, Trace, Tracer};
+use rquickjs::class::{Class, JsClass, Readable, Trace, Tracer};
 use rquickjs::function::{Constructor, This};
-use rquickjs::{Context, Ctx, FromJs, Function, IntoJs, Object, Result, Runtime, Value};
+use rquickjs::{Context, Ctx, FromJs, Function, IntoJs, JsLifetime, Object, Result, Runtime, Value};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct RustData(Rc<str>);
@@ -24,15 +24,14 @@ impl<'js> IntoJs<'js> for RustData {
     }
 }
 
+unsafe impl<'js> JsLifetime<'js> for RustData {
+    type Changed<'to> = RustData;
+}
+
 impl<'js> JsClass<'js> for RustData {
     const NAME: &'static str = "RustData";
 
     type Mutable = Readable;
-
-    fn class_id() -> &'static ClassId {
-        static ID: ClassId = ClassId::new();
-        &ID
-    }
 
     fn prototype(ctx: &Ctx<'js>) -> Result<Option<Object<'js>>> {
         let proto = Object::new(ctx.clone())?;


### PR DESCRIPTION
|          |                               |
|----------|-------------------------------|
| mlua     | v0.10.1                       |
| rhai     | v1.20.0                       |
| rquickjs | v0.8.1                        |



Local testing shows a possible regression in rquickjs from v0.6.2 to v0.8.1.

Before:
![before-Sort Rust objects](https://github.com/user-attachments/assets/6937e64b-2179-4d88-8f3e-9077111252ec)
After:
![after-Sort Rust objects](https://github.com/user-attachments/assets/97aa2956-69db-47c3-ba1e-2233e72fb08e)