### PR TITLE
Implement GC for userdata objects in WebAssembly

### DIFF
--- a/scripts/sort_userdata.wasm.rs
+++ b/scripts/sort_userdata.wasm.rs
@@ -8,7 +8,6 @@ unsafe extern "C" {
     safe fn rand(limit: u32) -> u32;
 }
 
-#[derive(Copy, Clone)]
 struct RustData(u32);
 
 impl RustData {
@@ -16,7 +15,7 @@ impl RustData {
         RustData(rustdata_new(s.as_ptr() as u32, s.len() as u32))
     }
 
-    fn lt(self, other: Self) -> bool {
+    fn lt(&self, other: &Self) -> bool {
         rustdata_lt(self.0, other.0) != 0
     }
 }
@@ -32,8 +31,8 @@ fn generate_string(len: usize) -> String {
 fn partition(arr: &mut [RustData]) -> usize {
     let (lo, hi) = (0, arr.len() - 1);
     let pivot_idx = (lo + hi) / 2;
-    let pivot = arr[pivot_idx];
     arr.swap(pivot_idx, hi);
+    let Some((pivot, arr)) = arr.split_last_mut() else { return 0 };
     let mut j = lo;
     for i in lo..hi {
         if arr[i].lt(pivot) {
@@ -41,7 +40,9 @@ fn partition(arr: &mut [RustData]) -> usize {
             j += 1;
         }
     }
-    arr.swap(j, hi);
+    if let Some(arr_j) = arr.get_mut(j) {
+        std::mem::swap(arr_j, pivot);
+    }
     j
 }
 

--- a/scripts/sort_userdata.wasm.rs
+++ b/scripts/sort_userdata.wasm.rs
@@ -4,6 +4,7 @@
 #[link(wasm_import_module = "RustData")]
 unsafe extern "C" {
     safe fn rustdata_new(ptr: u32, len: u32) -> u32;
+    safe fn rustdata_delete(id: u32) -> ();
     safe fn rustdata_lt(this: u32, other: u32) -> u32;
     safe fn rand(limit: u32) -> u32;
 }
@@ -17,6 +18,12 @@ impl RustData {
 
     fn lt(&self, other: &Self) -> bool {
         rustdata_lt(self.0, other.0) != 0
+    }
+}
+
+impl Drop for RustData {
+    fn drop(&mut self) {
+        rustdata_delete(self.0);
     }
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::rc::Rc;
 
 use rand::Rng;
 #[cfg(feature = "wasmi")]
@@ -7,7 +7,7 @@ use wasmi::*;
 use wasmtime::*;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct RustData(Arc<str>);
+struct RustData(Rc<str>);
 
 type HostState = Vec<RustData>;
 


### PR DESCRIPTION
Add a simple allocator for userdata objects with amortized O(1) operations.
This is stand-in for using [reference types](https://webassembly.github.io/reference-types/core/syntax/types.html#syntax-reftype) to manage lifetimes. 

**Edit:** Also fixed some sub-optimal decisions with the initial implementation.
Criterion results comparing those changes to the base commit:
```
# wasmtime
time:   [4.5183 ms 4.5214 ms 4.5247 ms]
change: [-10.903% -10.430% -10.002%] (p = 0.00 < 0.05)
Performance has improved.

# wasmi
time:   [16.226 ms 16.242 ms 16.258 ms]
change: [-1.5925% -1.3000% -1.0401%] (p = 0.00 < 0.05)
Performance has improved.
```

Criterion results for the final patch that adds userdata object de-allocation:
```
# wasmtime
time:   [4.7141 ms 4.7172 ms 4.7226 ms]
change: [+4.1086% +4.5434% +5.1128%] (p = 0.00 < 0.05)
Performance has regressed.

# wasm
time:   [16.513 ms 16.536 ms 16.569 ms]
change: [+1.3836% +2.0302% +2.8970%] (p = 0.00 < 0.05)
Performance has regressed.
```