### PR TITLE
Add Koto benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,7 +135,7 @@ dependencies = [
  "boa_string",
  "indexmap",
  "num-bigint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -156,7 +171,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.8.5",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "ryu-js",
  "serde",
  "serde_json",
@@ -193,7 +208,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "phf",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "static_assertions",
 ]
 
@@ -206,7 +221,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "boa_macros",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -237,7 +252,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -255,7 +270,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "boa_interop",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "url",
 ]
 
@@ -267,7 +282,7 @@ checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
 dependencies = [
  "fast-float2",
  "paste",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "sptr",
  "static_assertions",
 ]
@@ -341,6 +356,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +395,12 @@ dependencies = [
  "ciborium-io",
  "half",
 ]
+
+[[package]]
+name = "circular-buffer"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67261db007b5f4cf8cba393c1a5c511a5cc072339ce16e12aeba1d7b9b77946"
 
 [[package]]
 name = "clap"
@@ -427,6 +462,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
@@ -500,7 +541,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -697,6 +738,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-name"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19af109a7f1118ab96e1fd2a0c87310787f791680fa71b4bbfa5dffbc358b08"
+dependencies = [
+ "derive-name-macros",
+]
+
+[[package]]
+name = "derive-name-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa60999fb9292247d7c7eec5dada22b4ba337394612b0d935616bf49964c8bfd"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,9 +800,21 @@ dependencies = [
 
 [[package]]
 name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "downcast-rs"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -951,6 +1023,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1209,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1214,6 +1313,98 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "koto"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2ada56ff09999817e696c57900e7ebe71da62c5f6fa74646e286b4734b7d4e"
+dependencies = [
+ "koto_bytecode",
+ "koto_parser",
+ "koto_runtime",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "koto_bytecode"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2420e2f212d8bb848e13246d990d0307286f991b8e3d01eaa29e7eb37f6a6845"
+dependencies = [
+ "circular-buffer",
+ "derive-name",
+ "dunce",
+ "koto_memory",
+ "koto_parser",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "koto_derive"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb81a3d1a2ceaac8639f11ef90cc45b3938daa67f3d73ca66e9543b4b30ee0d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "koto_lexer"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b65c2966dbe10714fb6820c48cf8d907f2389304be37c73f177312ca6f7ec8"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+ "unicode-xid",
+]
+
+[[package]]
+name = "koto_memory"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b952fc577bb9822b814032e25f6a92be073fbf17b129e38ecb6bbe3db28a9210"
+
+[[package]]
+name = "koto_parser"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f011723a530d2a1f2c281b8399081e08f9afc980043a9fc638962225630d92"
+dependencies = [
+ "derive-name",
+ "koto_lexer",
+ "koto_memory",
+ "smallvec",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "koto_runtime"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d8c029431be9e1406f8e5b3126766b0667e7ca3e4b31514074e0f2fdb0a572"
+dependencies = [
+ "chrono",
+ "downcast-rs 1.2.1",
+ "indexmap",
+ "instant",
+ "koto_bytecode",
+ "koto_derive",
+ "koto_lexer",
+ "koto_memory",
+ "koto_parser",
+ "rustc-hash 1.1.0",
+ "saturating_cast",
+ "smallvec",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1355,7 +1546,7 @@ dependencies = [
  "mlua-sys",
  "num-traits",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 2.1.1",
 ]
 
 [[package]]
@@ -1900,7 +2091,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",
  "log",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -2078,6 +2269,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -2123,6 +2320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "saturating_cast"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4972f129a0ea378b69fa7c186d63255606e362ad00795f00b869dea5265eb"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2341,7 @@ dependencies = [
  "boa_runtime",
  "criterion",
  "itertools 0.14.0",
+ "koto",
  "mlua",
  "rand 0.9.0",
  "rhai",
@@ -2522,6 +2726,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2709,7 +2919,7 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169aa7d84d3c7612b53784e8e87713ea538f72403beff7b9c4e688292c438cd2"
 dependencies = [
- "downcast-rs",
+ "downcast-rs 2.0.1",
  "libm",
 ]
 
@@ -3103,6 +3313,65 @@ dependencies = [
  "wasmparser 0.226.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-result"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "script_bench"
 
 [features]
 boa = ["boa_engine", "boa_gc", "boa_runtime"]
+koto = ["dep:koto", "dep:anyhow"]
 mlua_lua54 = ["mlua/lua54", "mlua/vendored"]
 mlua_luau = ["mlua/luau-jit"]
 rhai = ["dep:rhai", "dep:itertools", "dep:anyhow"]
@@ -23,6 +24,7 @@ itertools = { version = "0.14", optional = true }
 boa_engine = { version = "0.20.0", optional = true }
 boa_gc = { version = "0.20.0", optional = true }
 boa_runtime = { version = "0.20.0", optional = true }
+koto = { version = "0.15.3", optional = true }
 mlua = { version = "0.10.3", optional = true }
 rhai = { version = "1.21.0", optional = true }
 rquickjs = { version = "0.9.0", optional = true }
@@ -40,6 +42,11 @@ lto = true
 name = "boa"
 harness = false
 required-features = ["boa"]
+
+[[bench]]
+name = "koto"
+harness = false
+required-features = ["koto"]
 
 [[bench]]
 name = "mlua_lua54"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 The project goal is to benchmark most popular embedded scripting languages for Rust.
 
 - [boa](https://boajs.dev)
+- [koto](https://crates.io/crates/koto)
 - [mlua](https://crates.io/crates/mlua) (Lua 5.4 and Luau)
 - [rhai](https://crates.io/crates/rhai)
 - [rquickjs](https://crates.io/crates/rquickjs)
@@ -25,6 +26,7 @@ You also must have `wasm32-unknown-unknown` target installed for webassembly ben
 | OS       | Ubuntu 22.04, m6i.16xlarge    |
 | rustc    | v1.83.0                       |
 | boa      | v0.20.0                       |
+| koto     | v0.15.3                       |
 | mlua     | v0.10.3                       |
 | rhai     | v1.21.0                       |
 | rquickjs | v0.9.0                        |

--- a/benches/koto.rs
+++ b/benches/koto.rs
@@ -1,0 +1,18 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn benchmark(c: &mut Criterion) {
+    script_bench::koto::sort_userdata(|func| {
+        c.bench_function("Sort Rust objects", |b| {
+            b.iter(|| func());
+        });
+    })
+    .unwrap();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = benchmark,
+}
+
+criterion_main!(benches);

--- a/scripts/sort_userdata.koto
+++ b/scripts/sort_userdata.koto
@@ -1,0 +1,30 @@
+charset = ("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f")
+
+generate_string = |len|
+    data = []
+    for i in 0..len
+        data.push charset[rand(size charset)]
+    data.to_string()
+
+partition = |arr, lo, hi|
+    pivot_idx = ((lo + hi) / 2).floor()
+    pivot = arr[pivot_idx]
+    j = lo
+    for i in lo..hi
+        if arr[i] < pivot
+            arr[i], arr[j] = arr[j], arr[i]
+            j += 1
+    arr[j], arr[hi] = arr[hi], arr[j]
+    j
+
+quicksort = |arr, lo, hi|
+    while lo < hi
+        p = partition arr, lo, hi
+        quicksort arr, lo, (p - 1)
+        lo = p + 1
+
+export bench = ||
+    array = []
+    for _ in 0..10000
+        array.push RustData_new generate_string(8 + rand(16))
+    quicksort array, 0, (array.count() - 1)

--- a/src/koto.rs
+++ b/src/koto.rs
@@ -1,0 +1,59 @@
+use anyhow::{bail, Result};
+use koto::{derive::*, prelude::*, runtime};
+use std::rc::Rc;
+
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, KotoCopy, KotoType)]
+struct RustData(Rc<str>);
+
+#[koto_impl]
+impl RustData {
+    fn new_koto_object(s: &str) -> KObject {
+        let me = Self(s.into());
+        KObject::from(me)
+    }
+}
+
+impl KotoObject for RustData {
+    fn display(&self, ctx: &mut DisplayContext) -> runtime::Result<()> {
+        ctx.append(self.0.to_string());
+        Ok(())
+    }
+
+    fn less(&self, rhs: &KValue) -> runtime::Result<bool> {
+        if let KValue::Object(kobj) = rhs {
+            let rhs_dc = kobj.cast::<RustData>()?;
+            Ok(*self < *rhs_dc)
+        } else {
+            unexpected_type("RustData object", rhs)
+        }
+    }
+}
+
+pub fn sort_userdata(run: impl FnOnce(&mut dyn FnMut())) -> Result<()> {
+    let mut engine = Koto::default();
+    let prelude = engine.prelude();
+
+    prelude.add_fn("RustData_new", |ctx| match ctx.args() {
+        [KValue::Str(input)] => Ok(RustData::new_koto_object(input.as_str()).into()),
+        unexpected => unexpected_args("a string", unexpected),
+    });
+
+    prelude.add_fn("rand", |ctx| match ctx.args() {
+        [KValue::Number(n)] => {
+            let res = rand::random::<u32>() as i64 % i64::from(n);
+            Ok(res.into())
+        }
+        unexpected => unexpected_args("a number", unexpected),
+    });
+
+    engine.compile_and_run(include_str!("../scripts/sort_userdata.koto"))?;
+    let Some(bench) = engine.exports().get("bench") else {
+        bail!("Missing bench function");
+    };
+
+    run(&mut || {
+        engine.call_function(bench.clone(), &[]).unwrap();
+    });
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "boa")]
 pub mod boa;
+#[cfg(feature = "koto")]
+pub mod koto;
 #[cfg(any(feature = "mlua_lua54", feature = "mlua_luau"))]
 pub mod mlua;
 #[cfg(feature = "rhai")]


### PR DESCRIPTION
This is an updated version of #4 that updates the benchmark to use [Koto](https://koto.dev) `0.15`, and includes some improvements to the Koto script.

- Export a `bench` function rather than reinitializing the script on each run.
- Use a tuple for `charset` rather than a list.
- Use `size charset` rather than `charset.count()` (`count` counts via iteration rather than taking the tuple's size).
- Use `data.to_string()` rather than folding a series of temporary strings.

Results from running on my laptop:

![Sort Rust objects](https://github.com/user-attachments/assets/b9552f3d-2285-41e7-9ada-65ab1a3d81a3)
