### PR TITLE
Remove some unnecessary conversions from the Roto script

### DIFF
--- a/scripts/sort_userdata.roto
+++ b/scripts/sort_userdata.roto
@@ -16,7 +16,7 @@ fn swap(arr: List, i: i64, j: i64) {
 }
 
 fn partition(arr: List, lo: i64, hi: i64) -> i64 {
-    let pivot_idx = to_i64((to_f64(lo) + to_f64(hi)) / 2.0);
+    let pivot_idx = (lo + hi) / 2;
     let pivot = arr.get(pivot_idx);
     swap(arr, pivot_idx, hi);
     let j = lo;

--- a/src/roto.rs
+++ b/src/roto.rs
@@ -18,14 +18,6 @@ pub fn sort_userdata(
             rand::rng().random_range(0..n)
         }
 
-        fn to_f64(n: i64) -> f64 {
-            n as f64
-        }
-
-        fn to_i64(n: f64) -> i64 {
-            n.floor() as i64
-        }
-
         fn string_get(charset: Arc<str>, idx: i64) -> Arc<str> {
             charset[idx as usize..idx as usize + 1].into()
         }


### PR DESCRIPTION
Hi! Thanks for making this and including Roto! As the author of Roto, I of course have to make sure it does well on the benchmark, so here's a small improvement ;p

There's more to optimize, for example, a `swap` could be added to the `List` type, to reduce the number of calls to Rust, but that feels like it might be outside of the spirit of the benchmark. There's some other things that could be improved, but would make the code more convoluted so I won't add those either (e.g. faster string construction with a custom `StringBuf` type or adding a `char` type). They do give me good inspiration for the standard library though!