### PR TITLE
Roto: implement `List.swap` in Rust

### DIFF
--- a/scripts/sort_userdata.roto
+++ b/scripts/sort_userdata.roto
@@ -9,25 +9,19 @@ fn generate_string(len: i64, charset: String) -> String {
     result
 }
 
-fn swap(arr: List, i: i64, j: i64) {
-    let t = arr.get(i);
-    arr.set(i, arr.get(j));
-    arr.set(j, t);
-}
-
 fn partition(arr: List, lo: i64, hi: i64) -> i64 {
     let pivot_idx = (lo + hi) / 2;
     let pivot = arr.get(pivot_idx);
-    swap(arr, pivot_idx, hi);
+    arr.swap(pivot_idx, hi);
     let j = lo;
     while lo < hi {
         if arr.get(lo).lt(pivot) {
-            swap(arr, lo, j);
+            arr.swap(lo, j);
             j = j + 1;
         }
         lo = lo + 1;
     }
-    swap(arr, j, hi);
+    arr.swap(j, hi);
     return j;
 }
 

--- a/src/roto.rs
+++ b/src/roto.rs
@@ -53,12 +53,12 @@ pub fn sort_userdata(
                 this.0.0.borrow().get(idx as usize).cloned().expect("get valid list idx")
             }
 
-            fn set(this: Val<List>, idx: i64, val: Val<RustData>) {
-                *this.0.0.borrow_mut().get_mut(idx as usize).expect("set valid list idx") = val;
-            }
-
             fn len(this: Val<List>) -> i64 {
                 this.0.0.borrow().len() as i64
+            }
+
+            fn swap(self, i: i64, j: i64) {
+                self.0.0.borrow_mut().swap(i as usize, j as usize)
             }
         }
     };


### PR DESCRIPTION
Also removes the `set` method, which we no longer need.