### PR TITLE
Update Roto to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.32.3",
+ "gimli",
 ]
 
 [[package]]
@@ -84,11 +84,11 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "ariadne"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f5e3dca4e09a6f340a61a0e9c7b61e030c69fc27bf29d73218f7e5e3b7638f"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
 dependencies = [
- "unicode-width 0.1.14",
+ "unicode-width",
  "yansi",
 ]
 
@@ -514,24 +514,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.120.2"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bda640bdb33597583178887b25582520457258590a979344f3137a1e64a282"
+checksum = "2e3e54e050cc7dd34c0ab37c42b406beaa4e971b8eb964b59bf2d54096caf18a"
 dependencies = [
- "cranelift-codegen 0.120.2",
- "cranelift-frontend 0.120.2",
+ "cranelift-codegen 0.127.4",
+ "cranelift-frontend 0.127.4",
  "cranelift-jit",
  "cranelift-module",
- "cranelift-native 0.120.2",
-]
-
-[[package]]
-name = "cranelift-assembler-x64"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5023e06632d8f351c2891793ccccfe4aef957954904392434038745fb6f1f68"
-dependencies = [
- "cranelift-assembler-x64-meta 0.120.2",
+ "cranelift-native 0.127.4",
 ]
 
 [[package]]
@@ -544,12 +535,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.120.2"
+name = "cranelift-assembler-x64"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c4012b4c8c1f6eb05c0a0a540e3e1ee992631af51aa2bbb3e712903ce4fd65"
+checksum = "d6abf69c884fde2d9d4cc232a585fb18f16af3ae04c634315c84ebe158ded92d"
 dependencies = [
- "cranelift-srcgen 0.120.2",
+ "cranelift-assembler-x64-meta 0.127.4",
 ]
 
 [[package]]
@@ -562,12 +553,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.120.2"
+name = "cranelift-assembler-x64-meta"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6d883b4942ef3a7104096b8bc6f2d1a41393f159ac8de12aed27b25d67f895"
+checksum = "263d31fcdf83a10267e8c38b53bc8f7688dfbc331267fd8fdf5b22e0dc47a55b"
 dependencies = [
- "cranelift-entity 0.120.2",
+ "cranelift-srcgen 0.127.4",
 ]
 
 [[package]]
@@ -580,10 +571,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bitset"
-version = "0.120.2"
+name = "cranelift-bforest"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7b2ee9eec6ca8a716d900d5264d678fb2c290c58c46c8da7f94ee268175d17"
+checksum = "d459d5377c01c4472b71029caa2df41afaf47711676aa9b12d7414f15104637b"
+dependencies = [
+ "cranelift-entity 0.127.4",
+]
 
 [[package]]
 name = "cranelift-bitset"
@@ -596,29 +590,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-codegen"
-version = "0.120.2"
+name = "cranelift-bitset"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeda0892577afdce1ac2e9a983a55f8c5b87a59334e1f79d8f735a2d7ba4f4b4"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64 0.120.2",
- "cranelift-bforest 0.120.2",
- "cranelift-bitset 0.120.2",
- "cranelift-codegen-meta 0.120.2",
- "cranelift-codegen-shared 0.120.2",
- "cranelift-control 0.120.2",
- "cranelift-entity 0.120.2",
- "cranelift-isle 0.120.2",
- "gimli 0.31.1",
- "hashbrown 0.15.5",
- "log",
- "regalloc2 0.12.2",
- "rustc-hash",
- "serde",
- "smallvec",
- "target-lexicon",
-]
+checksum = "8283088d5823ba7856ab8d531b7c3654b24984748f9fd99dcf3210701fd1d065"
 
 [[package]]
 name = "cranelift-codegen"
@@ -635,27 +610,42 @@ dependencies = [
  "cranelift-control 0.125.2",
  "cranelift-entity 0.125.2",
  "cranelift-isle 0.125.2",
- "gimli 0.32.3",
+ "gimli",
  "hashbrown 0.15.5",
  "log",
  "pulley-interpreter",
- "regalloc2 0.13.2",
+ "regalloc2",
  "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-math",
+ "wasmtime-internal-math 38.0.2",
 ]
 
 [[package]]
-name = "cranelift-codegen-meta"
-version = "0.120.2"
+name = "cranelift-codegen"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e461480d87f920c2787422463313326f67664e68108c14788ba1676f5edfcd15"
+checksum = "7d3138316d8dd341d725d6ab1598750545c76ad32892837fde558edd68a01b43"
 dependencies = [
- "cranelift-assembler-x64-meta 0.120.2",
- "cranelift-codegen-shared 0.120.2",
- "cranelift-srcgen 0.120.2",
+ "bumpalo",
+ "cranelift-assembler-x64 0.127.4",
+ "cranelift-bforest 0.127.4",
+ "cranelift-bitset 0.127.4",
+ "cranelift-codegen-meta 0.127.4",
+ "cranelift-codegen-shared 0.127.4",
+ "cranelift-control 0.127.4",
+ "cranelift-entity 0.127.4",
+ "cranelift-isle 0.127.4",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math 40.0.4",
 ]
 
 [[package]]
@@ -672,10 +662,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-codegen-shared"
-version = "0.120.2"
+name = "cranelift-codegen-meta"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976584d09f200c6c84c4b9ff7af64fc9ad0cb64dffa5780991edd3fe143a30a1"
+checksum = "505cead19304a8dc8689e31b29038775c3f73f9d5ea7a5e33864437a1f46c6b6"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.127.4",
+ "cranelift-codegen-shared 0.127.4",
+ "cranelift-srcgen 0.127.4",
+ "heck",
+]
 
 [[package]]
 name = "cranelift-codegen-shared"
@@ -684,13 +680,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599cdc596922c5c2879d3319f848be1eb5bfd208c31d5b7c9cc46004a86f43bf"
 
 [[package]]
-name = "cranelift-control"
-version = "0.120.2"
+name = "cranelift-codegen-shared"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d43d70f4e17c545aa88dbf4c84d4200755d27c6e3272ebe4de65802fa6a955"
-dependencies = [
- "arbitrary",
-]
+checksum = "ce62ba94f570644ce7de6ed05bd39ca28936665dec10a2a1f6f2c531d6add45c"
 
 [[package]]
 name = "cranelift-control"
@@ -702,12 +695,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-entity"
-version = "0.120.2"
+name = "cranelift-control"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75418674520cb400c8772bfd6e11a62736c78fc1b6e418195696841d1bf91f1"
+checksum = "db6cfe339689c3926412a7060ab00ef3b2b43d936b537e7a3f696121be9d0eaa"
 dependencies = [
- "cranelift-bitset 0.120.2",
+ "arbitrary",
 ]
 
 [[package]]
@@ -722,15 +715,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-frontend"
-version = "0.120.2"
+name = "cranelift-entity"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8b1a91c86687a344f3c52dd6dfb6e50db0dfa7f2e9c7711b060b3623e1fdeb"
+checksum = "625518090e912bdfe3c41464bf97ae421f6044d4ca0f5c3267dcacdb352b033d"
 dependencies = [
- "cranelift-codegen 0.120.2",
- "log",
- "smallvec",
- "target-lexicon",
+ "cranelift-bitset 0.127.4",
 ]
 
 [[package]]
@@ -746,10 +736,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-isle"
-version = "0.120.2"
+name = "cranelift-frontend"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711baa4e3432d4129295b39ec2b4040cc1b558874ba0a37d08e832e857db7285"
+checksum = "17f652d40ddf3afb55be64d8979d312b52b384a8cebbcde1dd1c2e32ebcd4466"
+dependencies = [
+ "cranelift-codegen 0.127.4",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cranelift-isle"
@@ -758,45 +754,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa1059c4dddd329635d97a22e2dac6265c3df663eeffa42a737a5bb48c7b988a"
 
 [[package]]
-name = "cranelift-jit"
-version = "0.120.2"
+name = "cranelift-isle"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86eece6be06ba68ed88ea8acb59a528deffe9cee09f08f2a422bfec554e82995"
+checksum = "9f512767e83015f4baf6e732cabca93cea82907e3ab237f826ef64f7ece75eb6"
+
+[[package]]
+name = "cranelift-jit"
+version = "0.127.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb2c8d10ec6c2ca58be2b9e376fd33d65917c240c1354a900292ecb65cbf353"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.120.2",
- "cranelift-control 0.120.2",
- "cranelift-entity 0.120.2",
+ "cranelift-codegen 0.127.4",
+ "cranelift-control 0.127.4",
+ "cranelift-entity 0.127.4",
  "cranelift-module",
- "cranelift-native 0.120.2",
+ "cranelift-native 0.127.4",
  "libc",
  "log",
  "region",
  "target-lexicon",
- "wasmtime-jit-icache-coherence",
- "windows-sys 0.59.0",
+ "wasmtime-internal-jit-icache-coherence 40.0.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cranelift-module"
-version = "0.120.2"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0065b75e59fcd32cfb50f754d6daf56235a2914eecb29e61aa2b4250a095c4c"
+checksum = "020f80e7d0d077bf101561cf0d55beaf8cf75a6a9f8ed5febcdb34df4969b44d"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.120.2",
- "cranelift-control 0.120.2",
-]
-
-[[package]]
-name = "cranelift-native"
-version = "0.120.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c83e8666e3bcc5ffeaf6f01f356f0e1f9dcd69ce5511a1efd7ca5722001a3f"
-dependencies = [
- "cranelift-codegen 0.120.2",
- "libc",
- "target-lexicon",
+ "cranelift-codegen 0.127.4",
+ "cranelift-control 0.127.4",
 ]
 
 [[package]]
@@ -811,16 +802,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-srcgen"
-version = "0.120.2"
+name = "cranelift-native"
+version = "0.127.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e3f4d783a55c64266d17dc67d2708852235732a100fc40dd9f1051adc64d7b"
+checksum = "cb1ca6e4dca568ff988d367e4707be2362cee9782265b0a501eaf467ffd550a8"
+dependencies = [
+ "cranelift-codegen 0.127.4",
+ "libc",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cranelift-srcgen"
 version = "0.125.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08dfb167733dfc164cc4601da4aa6cc95d98ca26251680643d134853bbe49d0"
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.127.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97400ad8fbd3a434092fc0b486fa7784150b53187941d818b1087f3ac0a547f0"
 
 [[package]]
 name = "crc32fast"
@@ -1359,17 +1361,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-dependencies = [
- "fallible-iterator",
- "indexmap",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
@@ -1725,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "109765b6fd703ea2cbfd7dd5dc40e5504fe48983f71120643e2ca3ad3a4f5d56"
 dependencies = [
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width",
  "unicode-xid",
 ]
 
@@ -2275,7 +2266,7 @@ dependencies = [
  "cranelift-bitset 0.125.2",
  "log",
  "pulley-macros",
- "wasmtime-internal-math",
+ "wasmtime-internal-math 38.0.2",
 ]
 
 [[package]]
@@ -2375,23 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.12.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.5",
- "log",
- "rustc-hash",
- "smallvec",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd8138ce7c3d7c13be4f61893154b5d711bd798d2d7be3ecb8dcc7e7a06ca98"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -2482,27 +2459,29 @@ dependencies = [
 
 [[package]]
 name = "roto"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705bd549031bcc891fd5c810c95ee3dc744b60fd8731f70e92d492b5208a4df2"
+checksum = "043bc6ac4a395f568b72f13f36c25a125329f82d1588d6332db5207d26d93e0f"
 dependencies = [
  "ariadne",
  "cranelift",
- "cranelift-codegen 0.120.2",
+ "cranelift-codegen 0.127.4",
+ "cranelift-jit",
  "inetnum",
  "libc",
  "log",
  "roto-macros",
  "rustc-literal-escaper",
+ "sealed",
  "symbol_table",
  "unicode-ident",
 ]
 
 [[package]]
 name = "roto-macros"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e3ba983c911c551cd501c8dac62f8f68e2dbeb5ed75de2288e8e53288c4d7f"
+checksum = "249940fa5c4df2ca7d4be84172b0995786a758fdd0d0a99f1b8e8b73288d1292"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2550,9 +2529,9 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-literal-escaper"
-version = "0.0.4"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab03008eb631b703dd16978282ae36c73282e7922fe101a4bd072a40ecea7b8b"
+checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
 
 [[package]]
 name = "rustc_version"
@@ -2639,6 +2618,17 @@ dependencies = [
  "rquickjs",
  "wasmi",
  "wasmtime",
+]
+
+[[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2821,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "symbol_table"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f19bffd69fb182e684d14e3c71d04c0ef33d1641ac0b9e81c712c734e83703bc"
+checksum = "aabf1e4bbb0a27b4b9bf61d9f634f6ef9d897bc139454b111e1f0cd4bfbe5641"
 dependencies = [
  "crossbeam-utils",
  "foldhash 0.1.5",
@@ -3137,21 +3127,15 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3416,7 +3400,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
- "gimli 0.32.3",
+ "gimli",
  "hashbrown 0.15.5",
  "indexmap",
  "ittapi",
@@ -3445,8 +3429,8 @@ dependencies = [
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
+ "wasmtime-internal-jit-icache-coherence 38.0.2",
+ "wasmtime-internal-math 38.0.2",
  "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
@@ -3465,7 +3449,7 @@ dependencies = [
  "cpp_demangle",
  "cranelift-bitset 0.125.2",
  "cranelift-entity 0.125.2",
- "gimli 0.32.3",
+ "gimli",
  "indexmap",
  "log",
  "object",
@@ -3536,7 +3520,7 @@ dependencies = [
  "cranelift-entity 0.125.2",
  "cranelift-frontend 0.125.2",
  "cranelift-native 0.125.2",
- "gimli 0.32.3",
+ "gimli",
  "itertools 0.14.0",
  "log",
  "object",
@@ -3546,7 +3530,7 @@ dependencies = [
  "thiserror 2.0.17",
  "wasmparser 0.239.0",
  "wasmtime-environ",
- "wasmtime-internal-math",
+ "wasmtime-internal-math 38.0.2",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
@@ -3591,10 +3575,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "40.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc57f590ba7ea967ea9e8c8560175c6926e5b15d11c29bbde3ad0013a29470eb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wasmtime-internal-math"
 version = "38.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28656769d952cd0fc964c8d2a37839f423dc85eb6c39e94cb840c4b0fe078486"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "40.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07612904518d47b677e8db67ca47c16d8c8cefb0099020729f886776950cb58b"
 dependencies = [
  "libm",
 ]
@@ -3637,7 +3642,7 @@ checksum = "c17ec692680e9d31563fa7ea1ba4bd134d02ad6ff4419a31b66fbf9981850776"
 dependencies = [
  "anyhow",
  "cranelift-codegen 0.125.2",
- "gimli 0.32.3",
+ "gimli",
  "log",
  "object",
  "target-lexicon",
@@ -3661,18 +3666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-jit-icache-coherence"
-version = "33.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7af0e940cb062a45c0b3f01a926f77da5947149e99beb4e3dd9846d5b8f11619"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "wast"
 version = "240.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,7 +3674,7 @@ dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
- "unicode-width 0.2.2",
+ "unicode-width",
  "wasm-encoder 0.240.0",
 ]
 
@@ -3755,15 +3748,15 @@ dependencies = [
  "anyhow",
  "cranelift-assembler-x64 0.125.2",
  "cranelift-codegen 0.125.2",
- "gimli 0.32.3",
- "regalloc2 0.13.2",
+ "gimli",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
  "wasmparser 0.239.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
+ "wasmtime-internal-math 38.0.2",
 ]
 
 [[package]]
@@ -3910,15 +3903,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ boa_runtime = { version = "0.21.0", optional = true }
 koto = { version = "0.16.0", optional = true }
 mlua = { version = "0.11.4", optional = true }
 rhai = { version = "1.23.4", optional = true }
-roto = { version = "0.9.0", optional = true, default-features = false }
+roto = { version = "0.11.0", optional = true, default-features = false }
 rquickjs = { version = "0.9.0", optional = true }
 wasmi = { version = "0.51.1", optional = true }
 wasmtime = { version = "38.0.2", optional = true }

--- a/benches/roto.rs
+++ b/benches/roto.rs
@@ -1,5 +1,4 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-
 use script_bench::roto::RustData;
 
 fn benchmark(c: &mut Criterion) {
@@ -11,11 +10,9 @@ fn benchmark(c: &mut Criterion) {
             // Validate that the results are sorted
             let mut count = 0;
             let mut prev = RustData::default();
-            let list = &list.0;
-            let list = list.0.borrow();
-            list.iter().for_each(|next| {
-                let next = &next.0;
-                assert!(prev.0 <= next.0);
+            list.into_iter().for_each(|next| {
+                let next = next.0;
+                assert!(&*prev.0 <= &*next.0);
                 prev = next.clone();
                 count += 1;
             });

--- a/scripts/sort_userdata.roto
+++ b/scripts/sort_userdata.roto
@@ -1,21 +1,30 @@
-fn generate_string(len: i64, charset: String) -> String {
-    let result = "";
+const CHARSET: String = "012345678abcdef";
+
+fn generate_string(len: u64) -> String {
+    let result = [];
     let i = 0;
     while i < len {
-        result = result.append(string_get(charset, rand(string_len(charset))));
+        result.push(CHARSET.get(rand(CHARSET.len())));
         i = i + 1;
     }
 
-    result
+    result.join("")
 }
 
-fn partition(arr: List, lo: i64, hi: i64) -> i64 {
+fn get_or_empty(arr: List[RustData], idx: u64) -> RustData {
+    match arr.get(idx) {
+        Some(s) => s,
+        None => RustData.new(""),
+    }
+}
+
+fn partition(arr: List[RustData], lo: u64, hi: u64) -> u64 {
     let pivot_idx = (lo + hi) / 2;
-    let pivot = arr.get(pivot_idx);
+    let pivot = get_or_empty(arr, pivot_idx);
     arr.swap(pivot_idx, hi);
     let j = lo;
     while lo < hi {
-        if arr.get(lo).lt(pivot) {
+        if get_or_empty(arr, lo).lt(pivot) {
             arr.swap(lo, j);
             j = j + 1;
         }
@@ -25,22 +34,22 @@ fn partition(arr: List, lo: i64, hi: i64) -> i64 {
     return j;
 }
 
-fn quicksort(arr: List, lo: i64, hi: i64) {
+fn quicksort(arr: List[RustData], lo: u64, hi: u64) {
     while lo < hi {
         let p = partition(arr, lo, hi);
-        quicksort(arr, lo, p - 1);
-        # Tail recursion
+        if p > 0 {
+            quicksort(arr, lo, p - 1);
+        }
+        // Tail recursion
         lo = p + 1;
     }
 }
 
-fn bench() -> List {
-    let charset = "0123456789abcdef";
-
-    let list = List.new();
+fn bench() -> List[RustData] {
+    let list = [];
     let i = 0;
     while i < 10000 {
-        list.push(RustData.new(generate_string(8 + rand(16), charset)));
+        list.push(RustData.new(generate_string(8 + rand(16))));
         i = i + 1;
     }
     quicksort(list, 0, list.len() - 1);

--- a/src/roto.rs
+++ b/src/roto.rs
@@ -1,64 +1,37 @@
-use std::{cell::RefCell, rc::Rc, sync::Arc};
-
 use rand::Rng;
-use roto::{library, Runtime, Val};
+use roto::{library, List, RotoString, Runtime, Val};
 
-#[derive(Clone, Default)]
-pub struct RustData(pub Arc<str>);
-
-#[derive(Clone)]
-pub struct List(pub Rc<RefCell<Vec<Val<RustData>>>>);
+#[derive(Clone, Default, PartialEq)]
+pub struct RustData(pub RotoString);
 
 pub fn sort_userdata(
     run: impl FnOnce(&mut dyn FnMut()),
-    validate: impl FnOnce(Val<List>),
+    validate: impl FnOnce(List<Val<RustData>>),
 ) -> anyhow::Result<()> {
     let lib = library! {
-        fn rand(n: i64) -> i64 {
+        fn rand(n: u64) -> u64 {
             rand::rng().random_range(0..n)
         }
 
-        fn string_get(charset: Arc<str>, idx: i64) -> Arc<str> {
-            charset[idx as usize..idx as usize + 1].into()
-        }
+        impl RotoString {
+            fn get(self, idx: u64) -> RotoString {
+                self[idx as usize..idx as usize + 1].into()
+            }
 
-        fn string_len(s: Arc<str>) -> i64 {
-            s.len() as i64
+            fn len(self) -> u64 {
+                self.bytes().len() as u64
+            }
         }
 
         #[clone] type RustData = Val<RustData>;
 
         impl Val<RustData> {
-            fn new(s: Arc<str>) -> Val<RustData> {
+            fn new(s: RotoString) -> Val<RustData> {
                 Val(RustData(s))
             }
 
             fn lt(this: Val<RustData>, rhs: Val<RustData>) -> bool {
-                this.0.0 < rhs.0.0
-            }
-        }
-
-        #[clone] type List = Val<List>;
-
-        impl Val<List> {
-            fn new() -> Val<List> {
-                Val(List(Rc::new(RefCell::new(Vec::new()))))
-            }
-
-            fn push(this: Val<List>, rd: Val<RustData>) {
-                this.0.0.borrow_mut().push(rd);
-            }
-
-            fn get(this: Val<List>, idx: i64) -> Val<RustData> {
-                this.0.0.borrow().get(idx as usize).cloned().expect("get valid list idx")
-            }
-
-            fn len(this: Val<List>) -> i64 {
-                this.0.0.borrow().len() as i64
-            }
-
-            fn swap(self, i: i64, j: i64) {
-                self.0.0.borrow_mut().swap(i as usize, j as usize)
+                &*this.0.0 < &*rhs.0.0
             }
         }
     };
@@ -66,11 +39,11 @@ pub fn sort_userdata(
     let runtime = Runtime::from_lib(lib)?;
     let mut compiled = runtime.compile("scripts/sort_userdata.roto")?;
 
-    let func = compiled.get_function::<(), fn() -> Val<List>>("bench")?;
+    let func = compiled.get_function::<fn() -> List<Val<RustData>>>("bench")?;
 
-    validate(func.call(&mut ()));
+    validate(func.call());
     run(&mut || {
-        func.call(&mut ());
+        func.call();
     });
 
     Ok(())


### PR DESCRIPTION
This updates the Roto version with some newer features such as the built-in lists and constants.

I tried to mimic the Lua version as closely as possible.

- There's no longer a need to register a custom list type so that simplifies the registration.
- The charset is now a constant.
- The string is generated by making a list of strings first and then joining it (as discussed a while ago in https://github.com/khvzak/script-bench-rs/pull/17). We could speed this up by creating a list of characters, but that feels too different from the other languages.
- We change from `i64` to `u64` for indices because that's what Roto lists use, which requires an extra `if p > 0` to make it not loop forever.

I'm not sure what this will do to the actual benchmarks, it might even regress, but the code is more idiomatic!